### PR TITLE
Fix dropdown API path

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Grupo;
+use App\Models\Clase;
 
 class GrupoController extends Controller
 {
@@ -60,5 +62,16 @@ class GrupoController extends Controller
     public function destroy(string $id)
     {
         //
+    }
+
+    public function dropdownData()
+    {
+        $grupos = Grupo::all();
+        $clases = Clase::all();
+
+        return response()->json([
+            'grupos' => $grupos,
+            'clases' => $clases,
+        ]);
     }
 }

--- a/app/Http/Controllers/OrquideaController.php
+++ b/app/Http/Controllers/OrquideaController.php
@@ -49,6 +49,10 @@ class OrquideaController extends Controller
 
         Orquidea::create($data);
 
+        if ($request->expectsJson()) {
+            return response()->json(['message' => 'Orquídea registrada'], 201);
+        }
+
         return redirect()->route('orquideas.index');
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GrupoController;
+use App\Http\Controllers\OrquideaController;
+
+Route::get('/dropdowns', [GrupoController::class, 'dropdownData']);
+Route::post('/orquideas', [OrquideaController::class, 'store']);


### PR DESCRIPTION
## Summary
- hook up API routing for dropdowns and orchid registration
- return dropdown data from `GrupoController`
- return JSON when orchid is stored

## Testing
- `composer test` *(fails: vendor autoload not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885b2a5831883289c7e881cb9d0fff2