### PR TITLE
Fix missing API routes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )


### PR DESCRIPTION
## Summary
- load `routes/api.php` so `/api/*` endpoints work

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_6885b99851b08328801345065f151a8a