### PR TITLE
Fix dropdown API

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Grupo;
+use App\Models\Clase;
 
 class GrupoController extends Controller
 {
@@ -60,5 +62,19 @@ class GrupoController extends Controller
     public function destroy(string $id)
     {
         //
+    }
+
+    /**
+     * Return data for dropdown selectors.
+     */
+    public function dropdownData()
+    {
+        $grupos = Grupo::select('id_grupo', 'nombre_grupo', 'Cod_Grupo')->get();
+        $clases = Clase::select('id_clase', 'nombre_clase', 'id_grupp')->get();
+
+        return response()->json([
+            'grupos' => $grupos,
+            'clases' => $clases,
+        ]);
     }
 }

--- a/app/Http/Controllers/OrquideaController.php
+++ b/app/Http/Controllers/OrquideaController.php
@@ -47,7 +47,11 @@ class OrquideaController extends Controller
             'id_case' => ['required', 'exists:tb_clase,id_clase'],
         ]);
 
-        Orquidea::create($data);
+        $orquidea = Orquidea::create($data);
+
+        if ($request->wantsJson()) {
+            return response()->json($orquidea, 201);
+        }
 
         return redirect()->route('orquideas.index');
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GrupoController;
+use App\Http\Controllers\OrquideaController;
+
+Route::get('/dropdowns', [GrupoController::class, 'dropdownData']);
+Route::post('/orquideas', [OrquideaController::class, 'store']);


### PR DESCRIPTION
## Summary
- support API routes in bootstrap config
- add dropdown API controller action
- register API routes
- return JSON from Orquidea store when requested

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `npm run lint` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885ca19b2288328a0bcfc3b2952a7cd