### PR TITLE
Fix API route loading

### DIFF
--- a/app/Http/Middleware/CorsMiddleware.php
+++ b/app/Http/Middleware/CorsMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CorsMiddleware
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\CorsMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
@@ -20,6 +22,9 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+        ]);
+        $middleware->api(prepend: [
+            CorsMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/resources/js/pages/registro_orquideas/index.tsx
+++ b/resources/js/pages/registro_orquideas/index.tsx
@@ -33,8 +33,7 @@ interface DropdownData {
 export default function OrchidRegistration() {
 
   const API_BASE =
-    import.meta.env.VITE_API_BASE_URL ??
-    (typeof window !== 'undefined' ? window.location.origin : '')
+    import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 
   const [quantity, setQuantity] = useState(1)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,5 +5,5 @@ use App\Http\Controllers\GrupoController;
 use App\Http\Controllers\ClaseController;
 use App\Http\Controllers\OrquideaController;
 
-Route::get('/dropdowns', [GrupoController::class, 'dropdownData']); // trae grupos y clases
-Route::post('/orquideas', [OrquideaController::class, 'store']);    // registrar orquídea
+Route::get('dropdowns', [GrupoController::class, 'dropdownData']); // trae grupos y clases
+Route::post('orquideas', [OrquideaController::class, 'store']);    // registrar orquídea


### PR DESCRIPTION
## Summary
- load api routes by registering the api.php file
- add a CORS middleware for API requests
- adjust API base fallback and route definitions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: Cannot find module '@inertiajs/react')*
- `npm run format:check` *(fails: Cannot find package 'prettier-plugin-organize-imports')*


------
https://chatgpt.com/codex/tasks/task_e_6885cae8bafc8328960040253965124c