### PR TITLE
Implement orchid management module

### DIFF
--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -35,6 +35,11 @@ const menuItems = [
     icon: Plus,
   },
   {
+    title: "Ver Orquídeas",
+    url: "/orquideas",
+    icon: Eye,
+  },
+  {
     title: "Identificación",
     url: "/identificacion",
     icon: Search,

--- a/resources/js/pages/orquideas/form.tsx
+++ b/resources/js/pages/orquideas/form.tsx
@@ -1,0 +1,83 @@
+import { useForm, Link } from '@inertiajs/react';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+
+interface Option { id:number|string; nombre_grupo?:string; nombre_clase?:string; nombre?:string; id_grupp?:number; }
+interface PageProps {
+  orquidea?: any;
+  grupos: Option[];
+  clases: Option[];
+  participantes: Option[];
+}
+
+export default function Form({ orquidea, grupos, clases, participantes }: PageProps) {
+  const { data, setData, post, processing, put } = useForm({
+    nombre_planta: orquidea?.nombre_planta || '',
+    origen: orquidea?.origen || '',
+    id_grupo: orquidea?.id_grupo || '',
+    id_case: orquidea?.id_case || '',
+    a: orquidea?.a || '',
+    foto: null as File | null,
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== null) formData.append(key, value as any);
+    });
+    if (orquidea) {
+      put(route('orquideas.update', orquidea.id_orquidea), { data: formData });
+    } else {
+      post(route('orquideas.store'), { data: formData });
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4 p-4 max-w-xl">
+      <Input
+        value={data.nombre_planta}
+        onChange={(e) => setData('nombre_planta', e.target.value)}
+        placeholder="Nombre de la Planta"
+        required
+      />
+      <Select value={data.origen} onValueChange={(v) => setData('origen', v)}>
+        <SelectTrigger><SelectValue placeholder="Origen" /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="especie">Especie</SelectItem>
+          <SelectItem value="hibrido">Híbrido</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select value={data.id_grupo} onValueChange={(v)=>setData('id_grupo', v)}>
+        <SelectTrigger><SelectValue placeholder="Grupo" /></SelectTrigger>
+        <SelectContent>
+          {grupos.map(g=>(
+            <SelectItem key={g.id} value={String(g.id)}>{g.nombre_grupo}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={data.id_case} onValueChange={(v)=>setData('id_case', v)}>
+        <SelectTrigger><SelectValue placeholder="Clase" /></SelectTrigger>
+        <SelectContent>
+          {clases.filter(c=>String(c.id_grupp)===String(data.id_grupo)).map(c=>(
+            <SelectItem key={c.id} value={String(c.id)}>{c.nombre_clase}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={data.a} onValueChange={(v)=>setData('a', v)}>
+        <SelectTrigger><SelectValue placeholder="Participante" /></SelectTrigger>
+        <SelectContent>
+          {participantes.map(p=>(
+            <SelectItem key={p.id} value={String(p.id)}>{p.nombre}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input type="file" onChange={e=>setData('foto', e.target.files?.[0]||null)} />
+      <div className="space-x-2">
+        <Button type="submit" disabled={processing}>Guardar</Button>
+        <Button variant="outline" asChild><Link href={route('orquideas.index')}>Cancelar</Link></Button>
+      </div>
+    </form>
+  );
+}

--- a/resources/js/pages/orquideas/index.tsx
+++ b/resources/js/pages/orquideas/index.tsx
@@ -1,157 +1,53 @@
-"use client"
-
-import React, { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { Eye, Edit, Trash2, Flower2, Menu, Home, FileText } from "lucide-react"
+import { Link, usePage } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
 
 interface Orquidea {
-  id: number
-  correlativo: string
-  participante: string
-  grupo_codigo: string
-  clase: string
-  grupo_nombre: string
+  id_orquidea: number;
+  codigo_orquide: string;
+  participante?: { nombre: string };
+  grupo?: { Cod_Grupo: string; nombre_grupo: string };
+  clase?: { nombre_clase: string };
 }
 
-const mockOrquideas: Orquidea[] = [
-  { id: 1, correlativo: "001", participante: "Juan Lopez", grupo_codigo: "A", clase: "Clase 1", grupo_nombre: "Grupo A" },
-  { id: 2, correlativo: "002", participante: "Maria Perez", grupo_codigo: "D", clase: "Clase 2", grupo_nombre: "Grupo D" },
-  { id: 3, correlativo: "003", participante: "Carlos Ruiz", grupo_codigo: "E", clase: "Clase 3", grupo_nombre: "Grupo E" },
-]
+interface PageProps { orquideas: { data: Orquidea[] } }
 
-export default function OrchidList() {
-  const [search, setSearch] = useState("")
-  const [grupo, setGrupo] = useState("")
-
-  const filtered = mockOrquideas
-    .filter(o => (grupo === "" || o.grupo_codigo === grupo))
-    .filter(o => o.participante.toLowerCase().includes(search.toLowerCase()))
-
-  const Sidebar = () => (
-    <div className="w-64 bg-slate-800 text-white h-screen p-4 space-y-2">
-      <div className="flex items-center gap-2 mb-8">
-        <Flower2 className="h-6 w-6 text-green-400" />
-        <span className="font-semibold">OrchidApp</span>
-      </div>
-
-      <nav className="space-y-2">
-        <Button variant="ghost" className="w-full justify-start text-white hover:bg-slate-700">
-          <Home className="mr-2 h-4 w-4" />
-          Inicio
-        </Button>
-        <Button variant="ghost" className="w-full justify-start text-white hover:bg-slate-700">
-          <Flower2 className="mr-2 h-4 w-4" />
-          Registro de Orquídeas
-        </Button>
-        <Button variant="ghost" className="w-full justify-start text-white hover:bg-slate-700 bg-slate-700">
-          <Eye className="mr-2 h-4 w-4" />
-          Ver Orquídeas
-        </Button>
-        <Button variant="ghost" className="w-full justify-start text-white hover:bg-slate-700">
-          <FileText className="mr-2 h-4 w-4" />
-          Abrir PDF
-        </Button>
-      </nav>
-    </div>
-  )
-
+export default function Index() {
+  const { orquideas } = usePage<PageProps>().props;
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <div className="hidden lg:block">
-        <Sidebar />
+    <div className="p-4">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-lg font-semibold">Listado de Orquídeas</h1>
+        <Button asChild><Link href={route('orquideas.create')}>Agregar Nuevo Registro</Link></Button>
       </div>
-
-      <Sheet>
-        <SheetTrigger asChild>
-          <Button variant="outline" size="icon" className="lg:hidden fixed top-4 left-4 z-50">
-            <Menu className="h-4 w-4" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent side="left" className="p-0 w-64">
-          <Sidebar />
-        </SheetContent>
-      </Sheet>
-
-      <div className="flex-1 p-4 lg:p-8">
-        <div className="max-w-6xl mx-auto space-y-6">
-          <div className="flex items-center justify-between">
-            <div className="text-lg font-semibold flex items-center gap-2">
-              <Flower2 className="h-5 w-5 text-green-600" />
-              <span>{filtered.length} Orquídeas</span>
-            </div>
-            <Button>
-              Agregar Nuevo Registro
-            </Button>
-          </div>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Listado de Orquídeas</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Input
-                  placeholder="Buscar..."
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  className="sm:max-w-xs"
-                />
-                <Select value={grupo} onValueChange={setGrupo}>
-                  <SelectTrigger className="sm:max-w-xs">
-                    <SelectValue placeholder="Todos los grupos" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="">Todos</SelectItem>
-                    <SelectItem value="A">Grupo A</SelectItem>
-                    <SelectItem value="D">Grupo D</SelectItem>
-                    <SelectItem value="E">Grupo E</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left border border-collapse">
-                  <thead className="bg-gray-100">
-                    <tr>
-                      <th className="px-2 py-2 border">ID</th>
-                      <th className="px-2 py-2 border">Correlativo</th>
-                      <th className="px-2 py-2 border">Participante</th>
-                      <th className="px-2 py-2 border">Código Grupo</th>
-                      <th className="px-2 py-2 border">Clase</th>
-                      <th className="px-2 py-2 border">Nombre Grupo</th>
-                      <th className="px-2 py-2 border text-center">Acciones</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {filtered.map((o) => (
-                      <tr key={o.id} className="border-t text-center">
-                        <td className="px-2 py-2 border">{o.id}</td>
-                        <td className="px-2 py-2 border">{o.correlativo}</td>
-                        <td className="px-2 py-2 border">{o.participante}</td>
-                        <td className="px-2 py-2 border">{o.grupo_codigo}</td>
-                        <td className="px-2 py-2 border">{o.clase}</td>
-                        <td className="px-2 py-2 border">{o.grupo_nombre}</td>
-                        <td className="px-2 py-2 border">
-                          <div className="flex justify-center gap-2">
-                            <Button size="icon" variant="outline"><Eye size={16} /></Button>
-                            <Button size="icon" variant="secondary"><Edit size={16} /></Button>
-                            <Button size="icon" variant="destructive"><Trash2 size={16} /></Button>
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th className="border px-2">ID</th>
+            <th className="border px-2">Correlativo</th>
+            <th className="border px-2">Participante</th>
+            <th className="border px-2">Código Grupo</th>
+            <th className="border px-2">Clase</th>
+            <th className="border px-2">Nombre Grupo</th>
+            <th className="border px-2">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orquideas.data.map(o => (
+            <tr key={o.id_orquidea} className="border-t">
+              <td className="border px-2">{o.id_orquidea}</td>
+              <td className="border px-2">{o.codigo_orquide}</td>
+              <td className="border px-2">{o.participante?.nombre}</td>
+              <td className="border px-2">{o.grupo?.Cod_Grupo}</td>
+              <td className="border px-2">{o.clase?.nombre_clase}</td>
+              <td className="border px-2">{o.grupo?.nombre_grupo}</td>
+              <td className="border px-2 space-x-1">
+                <Link href={route('orquideas.show', o.id_orquidea)} className="text-blue-600">Ver</Link>
+                <Link href={route('orquideas.edit', o.id_orquidea)} className="text-green-600">Editar</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
-  )
+  );
 }
-

--- a/resources/js/pages/orquideas/show.tsx
+++ b/resources/js/pages/orquideas/show.tsx
@@ -1,0 +1,24 @@
+import { Link, usePage } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+
+interface PageProps { orquidea: any }
+
+export default function Show() {
+  const { orquidea } = usePage<PageProps>().props;
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-lg font-semibold">Detalle de Orquídea</h1>
+      <div>Nombre: {orquidea.nombre_planta}</div>
+      <div>Origen: {orquidea.origen}</div>
+      <div>Grupo: {orquidea.grupo?.nombre_grupo}</div>
+      <div>Clase: {orquidea.clase?.nombre_clase}</div>
+      <div>Participante: {orquidea.participante?.nombre}</div>
+      {orquidea.foto ? (
+        <img src={`/storage/orquideas/${orquidea.foto}`} className="max-w-xs" />
+      ) : (
+        <div>No hay foto disponible</div>
+      )}
+      <Button asChild variant="outline"><Link href={route('orquideas.index')}>Inicio</Link></Button>
+    </div>
+  );
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,4 +6,8 @@
     use App\Http\Controllers\OrquideaController;
 
 Route::get('dropdowns', [GrupoController::class, 'dropdownData']); // trae grupos y clases
-Route::post('orquideas', [OrquideaController::class, 'store']);    // registrar orquídea
+Route::get('orquideas', [OrquideaController::class, 'index']);
+Route::post('orquideas', [OrquideaController::class, 'store']);
+Route::get('orquideas/{orquidea}', [OrquideaController::class, 'show']);
+Route::put('orquideas/{orquidea}', [OrquideaController::class, 'update']);
+Route::delete('orquideas/{orquidea}', [OrquideaController::class, 'destroy']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,9 +21,15 @@ Route::get('/registro_orquideas', function () {
     return Inertia::render('registro_orquideas/index'); // Asegúrate de que coincida con la estructura de tu carpeta
 })->name('registro_orquideas');
 
-Route::get('/orquideas', function () {
-    return Inertia::render('orquideas/index');
-})->name('orquideas.index');
+Route::middleware('auth')->group(function () {
+    Route::get('/orquideas', [OrquideaController::class, 'index'])->name('orquideas.index');
+    Route::get('/orquideas/create', [OrquideaController::class, 'create'])->name('orquideas.create');
+    Route::post('/orquideas', [OrquideaController::class, 'store'])->name('orquideas.store');
+    Route::get('/orquideas/{orquidea}', [OrquideaController::class, 'show'])->name('orquideas.show');
+    Route::get('/orquideas/{orquidea}/edit', [OrquideaController::class, 'edit'])->name('orquideas.edit');
+    Route::put('/orquideas/{orquidea}', [OrquideaController::class, 'update'])->name('orquideas.update');
+    Route::delete('/orquideas/{orquidea}', [OrquideaController::class, 'destroy'])->name('orquideas.destroy');
+});
 
 //routes para los controladores
 


### PR DESCRIPTION
## Summary
- add Inertia-based controller actions for orquídeas
- register API and web routes
- show orchid links in sidebar
- create basic React pages for listing, form and detail

## Testing
- `composer test` *(fails: missing vendor directory)*
- `npm run lint` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68868c358f548328ab6fed8fd21b84df